### PR TITLE
storage setting tile class name update

### DIFF
--- a/data/css/_icons.scss
+++ b/data/css/_icons.scss
@@ -78,7 +78,7 @@ $icons-32: (
     settings-switch:        $mdi-switch,
     settings-freeplugs:     $mdi-ethernet-cable,
     settings-upnpigd:       $mdi-server-network,
-    settings-storage:       $mdi-harddisk,
+    settings-storage-storage:       $mdi-harddisk,
     settings-ftp:           $mdi-folder-move,
     settings-sharesamba:    $mdi-windows,
     settings-shareafp:      $mdi-apple,


### PR DESCRIPTION
Class name for the storage icon changed from "app-icons-32-settings-storage" to "app-icons-32-settings-storage-storage" in fbOS v4.